### PR TITLE
Restructure repository for Poetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Git Commit Loader
+
+A Python package to load and inspect Git commit objects using `git cat-file --batch`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "git-commit-loader"
+version = "0.1.0"
+description = "Load and parse Git commit objects"
+authors = ["Your Name <you@example.com>"]
+packages = [{ include = "git_commit_loader", from = "src" }]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+
+[tool.poetry.scripts]
+git-commit-loader = "git_commit_loader.__main__:main"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/src/git_commit_loader/__init__.py
+++ b/src/git_commit_loader/__init__.py
@@ -3,8 +3,6 @@
 
 import subprocess
 from collections import namedtuple
-import os
-import argparse
 import json
 import hashlib
 
@@ -182,45 +180,3 @@ class GitCommitLoader:
             output.append(d)
         return json.dumps(output, indent=2)
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Git commit loader utility')
-    parser.add_argument('repo_path', nargs='?', default=os.getcwd(),
-                        help='Path to the Git repository (default: current directory)')
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument('--list-branches', action='store_true',
-                       help='List branch names with their corresponding commit SHAs')
-    group.add_argument('--list-commits', action='store_true',
-                       help='Load and list commit objects')
-    parser.add_argument('--json', action='store_true',
-                        help='Output in JSON format')
-    parser.add_argument('--verify', action='store_true',
-                        help='Verify commit SHAs against raw content')
-    args = parser.parse_args()
-
-    loader = GitCommitLoader(repo_path=args.repo_path)
-
-    if args.verify:
-        mismatches = loader.verify_all_commits()
-        if mismatches:
-            print("Mismatched commits:")
-            for sha, rec in mismatches:
-                print(f"{sha} != {rec}")
-        else:
-            print("All commits verified successfully.")
-    elif args.list_branches:
-        if args.json:
-            print(loader.list_branches_json())
-        else:
-            branches = loader.get_branches()
-            for sha, names in branches.items():
-                for name in names:
-                    print(f"{name}: {sha}")
-    else:
-        # Default or --list-commits
-        if args.json:
-            print(loader.list_commits_json())
-        else:
-            commits = loader.load_commits()
-            print(f"Loaded {len(commits)} commits from {args.repo_path}")
-            for c in commits:
-                print(c)

--- a/src/git_commit_loader/__main__.py
+++ b/src/git_commit_loader/__main__.py
@@ -1,0 +1,51 @@
+import os
+import argparse
+from . import GitCommitLoader
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Git commit loader utility')
+    parser.add_argument('repo_path', nargs='?', default=os.getcwd(),
+                        help='Path to the Git repository (default: current directory)')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--list-branches', action='store_true',
+                       help='List branch names with their corresponding commit SHAs')
+    group.add_argument('--list-commits', action='store_true',
+                       help='Load and list commit objects')
+    parser.add_argument('--json', action='store_true',
+                        help='Output in JSON format')
+    parser.add_argument('--verify', action='store_true',
+                        help='Verify commit SHAs against raw content')
+    args = parser.parse_args()
+
+    loader = GitCommitLoader(repo_path=args.repo_path)
+
+    if args.verify:
+        mismatches = loader.verify_all_commits()
+        if mismatches:
+            print("Mismatched commits:")
+            for sha, rec in mismatches:
+                print(f"{sha} != {rec}")
+        else:
+            print("All commits verified successfully.")
+    elif args.list_branches:
+        if args.json:
+            print(loader.list_branches_json())
+        else:
+            branches = loader.get_branches()
+            for sha, names in branches.items():
+                for name in names:
+                    print(f"{name}: {sha}")
+    else:
+        # Default or --list-commits
+        if args.json:
+            print(loader.list_commits_json())
+        else:
+            commits = loader.load_commits()
+            print(f"Loaded {len(commits)} commits from {args.repo_path}")
+            for c in commits:
+                print(c)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- organize code into a package under `src/`
- provide a CLI entry point
- add `pyproject.toml` with Poetry configuration
- add basic README and `.gitignore`

## Testing
- `poetry install -n`
- `poetry run git-commit-loader --help`
- `poetry run git-commit-loader --list-branches --json | head`

------
https://chatgpt.com/codex/tasks/task_e_686340cec2c4832bb83b3f8a869d3e80