### PR TITLE
Fix path comparison in repo integration tests

### DIFF
--- a/tests/test_repo_dir_integration.py
+++ b/tests/test_repo_dir_integration.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import subprocess
 import tempfile
+from pathlib import Path
 
 from git_repo_inspector.repo_dir import RepoDir
 
@@ -18,9 +19,15 @@ class TestRepoDirIntegration(unittest.TestCase):
             subprocess.run(["git", "init", repo_path], check=True, capture_output=True)
             loader = RepoDir(repo_path=repo_path)
 
-            self.assertEqual(os.path.normpath(loader.absolute_git_dir), os.path.normpath(os.path.join(repo_path, ".git")))
+            self.assertEqual(
+                Path(loader.absolute_git_dir).resolve(),
+                Path(repo_path, ".git").resolve(),
+            )
             self.assertTrue(loader.is_inside_working_tree())
-            self.assertEqual(os.path.normpath(loader.get_toplevel_dir()), os.path.normpath(os.path.abspath(repo_path)))
+            self.assertEqual(
+                Path(loader.get_toplevel_dir()).resolve(),
+                Path(repo_path).resolve(),
+            )
             self.assertEqual(os.getcwd(), self.original_cwd)
 
     def test_bare_repository(self):
@@ -28,7 +35,10 @@ class TestRepoDirIntegration(unittest.TestCase):
             subprocess.run(["git", "init", "--bare", repo_path], check=True, capture_output=True)
             loader = RepoDir(repo_path=repo_path)
 
-            self.assertEqual(os.path.normpath(loader.absolute_git_dir), os.path.normpath(os.path.abspath(repo_path)))
+            self.assertEqual(
+                Path(loader.absolute_git_dir).resolve(),
+                Path(repo_path).resolve(),
+            )
             self.assertFalse(loader.is_inside_working_tree())
             self.assertIsNone(loader.toplevel_dir)
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
## Summary
- avoid string-based path comparison in tests
- use `Path.resolve()` for checking paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686388903cb4832ba8c8a133ae3b0364