### PR TITLE
Ensure clean environment for Git subprocesses

### DIFF
--- a/src/git_repo_inspector/__init__.py
+++ b/src/git_repo_inspector/__init__.py
@@ -1,2 +1,4 @@
 from .commit_loader import CommitLoader
 from .repo_dir import RepoDir
+
+__all__ = ["CommitLoader", "RepoDir"]

--- a/src/git_repo_inspector/branch_loader.py
+++ b/src/git_repo_inspector/branch_loader.py
@@ -1,4 +1,6 @@
 import subprocess
+
+from .env_utils import clean_git_env
 import argparse
 import os
 import json
@@ -30,7 +32,13 @@ class BranchLoader:
                 '--format=%(refname:short) %(objectname)',
                 'refs/heads/'
             ]
-            result: subprocess.CompletedProcess = subprocess.run(cmd, stdout=subprocess.PIPE, text=True, check=True)
+            result: subprocess.CompletedProcess = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                text=True,
+                check=True,
+                env=clean_git_env(),
+            )
             self.branch_map = {}
             for line in result.stdout.splitlines():
                 name, sha = line.split(None, 1)

--- a/src/git_repo_inspector/commit_loader.py
+++ b/src/git_repo_inspector/commit_loader.py
@@ -2,6 +2,8 @@
 # CommitLoader: Load and parse Git commit objects into memory using git cat-file --batch
 
 import subprocess
+
+from .env_utils import clean_git_env
 import json
 import hashlib
 from typing import List, Dict, Optional, Tuple, NamedTuple, Any
@@ -40,7 +42,13 @@ class CommitLoader:
         """
         if self.commit_shas is None:
             cmd: List[str] = ['git', '-C', self.repo_path, 'rev-list', '--all']
-            result: subprocess.CompletedProcess = subprocess.run(cmd, stdout=subprocess.PIPE, text=True, check=True)
+            result: subprocess.CompletedProcess = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                text=True,
+                check=True,
+                env=clean_git_env(),
+            )
             self.commit_shas = result.stdout.splitlines()
         return self.commit_shas
 
@@ -57,7 +65,12 @@ class CommitLoader:
         branch_map: Dict[str, List[str]] = self.get_branches()
         cmd_cat: List[str] = ['git', '-C', self.repo_path, 'cat-file', '--batch']
 
-        p_cat: subprocess.Popen = subprocess.Popen(cmd_cat, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        p_cat: subprocess.Popen = subprocess.Popen(
+            cmd_cat,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            env=clean_git_env(),
+        )
         for sha in shas:
             p_cat.stdin.write(f"{sha}\n".encode())
         p_cat.stdin.close()

--- a/src/git_repo_inspector/env_utils.py
+++ b/src/git_repo_inspector/env_utils.py
@@ -1,0 +1,24 @@
+import os
+from typing import Dict
+
+_GIT_ENV_VARS = [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_NO_DISCOVERY",
+    "GIT_TEMPLATE_DIR",
+    "GIT_CONFIG",
+]
+
+
+def clean_git_env() -> Dict[str, str]:
+    """Return a copy of :mod:`os.environ` with Git-related variables removed."""
+    env = os.environ.copy()
+    for var in _GIT_ENV_VARS:
+        env.pop(var, None)
+    return env

--- a/src/git_repo_inspector/repo_dir.py
+++ b/src/git_repo_inspector/repo_dir.py
@@ -1,4 +1,6 @@
 import subprocess
+
+from .env_utils import clean_git_env
 import os
 from typing import Optional
 
@@ -25,15 +27,21 @@ class RepoDir:
             # Get absolute Git directory (e.g., .git)
             result_git_dir = subprocess.run(
                 ['git', 'rev-parse', '--absolute-git-dir'],
-                capture_output=True, text=True, check=True
+                capture_output=True,
+                text=True,
+                check=True,
+                env=clean_git_env(),
             )
             self.absolute_git_dir: str = result_git_dir.stdout.strip()
 
             # Check if it's a bare repository
             result_is_bare = subprocess.run(
                 ['git', 'rev-parse', '--is-bare-repository'],
-                capture_output=True, text=True, check=True,
-                cwd=target_path # Run this command in the context of the target path
+                capture_output=True,
+                text=True,
+                check=True,
+                cwd=target_path,  # Run this command in the context of the target path
+                env=clean_git_env(),
             )
             self._is_bare: bool = result_is_bare.stdout.strip() == 'true'
 
@@ -42,7 +50,10 @@ class RepoDir:
                 # Get top-level working directory only for non-bare repositories
                 result_toplevel = subprocess.run(
                     ['git', 'rev-parse', '--show-toplevel'],
-                    capture_output=True, text=True, check=True
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    env=clean_git_env(),
                 )
                 self.toplevel_dir = result_toplevel.stdout.strip()
 

--- a/tests/test_branch_loader.py
+++ b/tests/test_branch_loader.py
@@ -1,6 +1,6 @@
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, ANY
 from git_repo_inspector.branch_loader import BranchLoader
 import subprocess
 
@@ -41,7 +41,8 @@ class TestBranchLoader(unittest.TestCase):
             expected_cmd,
             stdout=subprocess.PIPE,
             text=True,
-            check=True
+            check=True,
+            env=ANY,
         )
 
         # Assert the parsed branch map is correct

--- a/tests/test_commit_loader.py
+++ b/tests/test_commit_loader.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, ANY
 import json
 import hashlib
 from typing import List, Dict, Optional, Tuple, Any
@@ -27,7 +27,10 @@ class TestCommitLoader(unittest.TestCase):
         self.assertEqual(shas, ["sha1", "sha2", "sha3"])
         mock_run.assert_called_once_with(
             ['git', '-C', self.mock_repo_path, 'rev-list', '--all'],
-            stdout=subprocess.PIPE, text=True, check=True
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True,
+            env=ANY,
         )
         # Test caching
         shas_cached = self.loader.get_commit_shas()
@@ -93,7 +96,9 @@ class TestCommitLoader(unittest.TestCase):
 
         mock_popen.assert_called_once_with(
             ['git', '-C', self.mock_repo_path, 'cat-file', '--batch'],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            env=ANY,
         )
         mock_proc.stdin.write.assert_any_call(b"commit_sha_1\n")
         mock_proc.stdin.write.assert_any_call(b"commit_sha_2\n")


### PR DESCRIPTION
## Summary
- add `clean_git_env` utility to strip Git-related variables
- apply the cleaned environment to all subprocess Git commands
- export symbols in `__init__`
- adjust tests for new `env` parameter

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686393361ce8832baeb58f806aaa7472