### PR TITLE
Improve RepoDir error message with failing command

### DIFF
--- a/src/git_repo_inspector/repo_dir.py
+++ b/src/git_repo_inspector/repo_dir.py
@@ -47,7 +47,9 @@ class RepoDir:
                 self.toplevel_dir = result_toplevel.stdout.strip()
 
         except subprocess.CalledProcessError as e:
-            raise RuntimeError(f"Git command failed: {e.stderr}") from e
+            cmd = " ".join(e.cmd) if isinstance(e.cmd, (list, tuple)) else str(e.cmd)
+            stderr = e.stderr.strip() if e.stderr else ""
+            raise RuntimeError(f"Git command failed ({cmd}): {stderr}") from e
         except FileNotFoundError:
             raise RuntimeError("Git command not found. Please ensure Git is installed and in your PATH.")
         finally:

--- a/tests/test_repo_dir.py
+++ b/tests/test_repo_dir.py
@@ -64,7 +64,7 @@ class TestRepoDir(unittest.TestCase):
     @patch('subprocess.run', side_effect=subprocess.CalledProcessError(1, 'git', stderr="git error"))
     @patch('os.chdir')
     def test_init_git_command_failure(self, mock_chdir, mock_subprocess_run):
-        with self.assertRaisesRegex(RuntimeError, "Git command failed"): 
+        with self.assertRaisesRegex(RuntimeError, r"Git command failed \(git\): git error"):
             RepoDir()
         mock_subprocess_run.assert_called_once()
         mock_chdir.assert_called_with(self.original_cwd) # Ensure chdir is restored


### PR DESCRIPTION
## Summary
- enhance repo_dir error handling to include the failed git command
- adjust tests for new message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686475334a6c832b860e3eb0b3d60c8e